### PR TITLE
add ubuntu support; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A [Telegraf](https://github.com/influxdata/telegraf) plugin to check Debian, Ubu
 
 This plugin runs continuously and prints an output in the interval requested by Telegraf.
 In addition, the output can be triggered externally, e.g. during `apt update` to get the latest status in almost real time.
-For Debian, the Debian wiki is queried to check the [LTS status](https://wiki.debian.org/LTS). For Ubuntu, the meta-release changelog is queried to check the [support status](https://changelogs.ubuntu.com/meta-release).
+For Debian, the Debian wiki is queried to check the [LTS status](https://wiki.debian.org/LTS).
+For Ubuntu, the meta-release changelog is queried to check the [support status](https://changelogs.ubuntu.com/meta-release).
 You can make use of [needrestart](https://github.com/liske/needrestart) to check the system for outdated libraries.
 
 
@@ -50,11 +51,12 @@ apt os_codename="Bullseye"
 apt os_support=0
 apt updates_regular=0
 apt updates_security=1
-apt updates_packages=""
+apt updates_packages="" ?
 apt updates_severity=2
 apt needrestart_services=6
 apt needrestart_severity=1
 ```
+
 
 ## How to read
 
@@ -75,7 +77,8 @@ Returns the value of `VERSION_CODENAME` from `/etc/os-release`.
 
 **os_support**
 
-Returns the current support status of your system. Supported on Debian and Ubuntu only.
+Returns the current support status of your system.
+Supported on Debian and Ubuntu.
 
 For Debian:
 
@@ -85,14 +88,12 @@ For Debian:
 2   =  outdated
 ```
 
-For Ubuntu:
+For Ubuntu (This will not consider Ubuntu Pro support):
 
 ```
 0   =  supported
 2   =  unsupported
 ```
-
-_For Ubuntu this will not consider Ubuntu Pro licensing/extended support._
 
 
 **updates_regular**

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![Contributors](https://img.shields.io/github/contributors/x70b1/telegraf-apt.svg)](https://github.com/x70b1/telegraf-apt/graphs/contributors)
 [![License](https://img.shields.io/github/license/x70b1/telegraf-apt.svg)](https://github.com/x70b1/telegraf-apt/blob/master/LICENSE)
 
-A [Telegraf](https://github.com/influxdata/telegraf) plugin to check Debian for package updates.
+A [Telegraf](https://github.com/influxdata/telegraf) plugin to check Debian, Ubuntu and other apt-based systems for package updates.
 
 This plugin runs continuously and prints an output in the interval requested by Telegraf.
 In addition, the output can be triggered externally, e.g. during `apt update` to get the latest status in almost real time.
-The Debian wiki is queried to check the [LTS status](https://wiki.debian.org/LTS).
+For Debian, the Debian wiki is queried to check the [LTS status](https://wiki.debian.org/LTS). For Ubuntu, the meta-release changelog is queried to check the [support status](https://changelogs.ubuntu.com/meta-release).
 You can make use of [needrestart](https://github.com/liske/needrestart) to check the system for outdated libraries.
 
 
@@ -44,38 +44,55 @@ telegraf    ALL = NOPASSWD: /usr/sbin/needrestart -b
 
 ```sh
 # sh /opt/telegraf/telegraf-apt.sh
-apt debian_release="11.2"
-apt debian_codename="Bullseye"
-apt debian_support=0
+apt os_id="Debian"
+apt os_release="11.2"
+apt os_codename="Bullseye"
+apt os_support=0
 apt updates_regular=0
 apt updates_security=1
+apt updates_packages=""
 apt updates_severity=2
 apt needrestart_services=6
 apt needrestart_severity=1
 ```
 
-
 ## How to read
 
-**debian_release**
+**os_id**
 
-Returns the release from `/etc/debian_version`.
-
-
-**debian_codename**
-
-Returns a codename like `Bullseye`, `Buster` ...
+Returns the value of `ID` from `/etc/os-release`.
 
 
-**debian_support**
+**os_release**
 
-Returns the current support status of your system.
+Returns the value of `VERSION_ID` from `/etc/os-release`.
+
+
+**os_codename**
+
+Returns the value of `VERSION_CODENAME` from `/etc/os-release`.
+
+
+**os_support**
+
+Returns the current support status of your system. Supported on Debian and Ubuntu only.
+
+For Debian:
 
 ```
 0   =  full support with official security fixes
 1   =  LTS with limitied security support
 2   =  outdated
 ```
+
+For Ubuntu:
+
+```
+0   =  supported
+2   =  unsupported
+```
+
+_For Ubuntu this will not consider Ubuntu Pro licensing/extended support._
 
 
 **updates_regular**
@@ -95,7 +112,9 @@ Returns a list of packages with outstanding updates.
 
 **updates_severity**
 
-Returns an integer indicator as summary.
+Returns an integer indicator as summary for Debian and Ubuntu.
+
+For Debian:
 
 ```
 0   =  full Debian support, no updates
@@ -115,6 +134,20 @@ Returns an integer indicator as summary.
 23  =  outdated, one or more regular updates and one or more security updates
 ```
 
+For Ubuntu:
+
+```
+0   =  full Ubuntu support, no updates
+
+1   =  full Ubuntu support, one or more regular updates
+2   =  full Ubuntu support, one or more security updates
+3   =  full Ubuntu support, one or more regular updates and one or more security updates
+
+20  =  unsupported, no updates
+21  =  unsupported, one or more regular updates
+22  =  unsupported, one or more security updates
+23  =  unsupported, one or more regular updates and one or more security updates
+```
 
 **needrestart_services**
 

--- a/telegraf-apt.sh
+++ b/telegraf-apt.sh
@@ -12,27 +12,21 @@ case "$1" in
         trap "echo" USR1
 
         while true; do
-
             os_id=$(. /etc/os-release; echo "$ID" | sed 's/^[a-z]/\U&/g')
-
-            echo "apt os_id=\"$os_id\""
-
             os_codename=$(. /etc/os-release; echo "$VERSION_CODENAME" | sed 's/^[a-z]/\U&/g')
-
-            echo "apt os_codename=\"$os_codename\""
-
             os_release=$(. /etc/os-release; echo "$VERSION_ID")
 
+            echo "apt os_id=\"$os_id\""
+            echo "apt os_codename=\"$os_codename\""
             echo "apt os_release=\"$os_release\""
 
             if [ "$os_id" = "Debian" ]; then 
+                debian_support=$(curl -sf https://wiki.debian.org/LTS | grep "Debian $os_release")
 
-                release_ltsinfo=$(curl -sf https://wiki.debian.org/LTS | grep "Debian $os_release")
-
-                if [ -n "$release_ltsinfo" ]; then
-                    if echo "$release_ltsinfo" | grep -q "#98fb98"; then
+                if [ -n "$debian_support" ]; then
+                    if echo "$debian_support" | grep -q "#98fb98"; then
                         release_support=0
-                    elif echo "$release_ltsinfo" | grep -q "#FCED77"; then
+                    elif echo "$debian_support" | grep -q "#FCED77"; then
                         release_support=1
                     else
                         release_support=2
@@ -40,13 +34,11 @@ case "$1" in
 
                     echo "apt os_support=$release_support"
                 fi
-            
             elif [ "$os_id" = "Ubuntu" ]; then 
+                ubuntu_support=$(curl -sf https://changelogs.ubuntu.com/meta-release | grep -A 2 "Version: $os_release" | grep "Supported" | cut -d ' ' -f 2)
 
-                release_ltsinfo=$(curl -sf https://changelogs.ubuntu.com/meta-release | grep -A 2 "Version: $os_release" | grep "Supported" | cut -d ' ' -f 2)
-
-                if [ -n "$release_ltsinfo" ]; then
-                    if [ "$release_ltsinfo" -eq 1 ];then
+                if [ -n "$ubuntu_support" ]; then
+                    if [ "$ubuntu_support" -eq 1 ];then
                         release_support=0
                     else
                         release_support=2
@@ -54,7 +46,6 @@ case "$1" in
 
                     echo "apt os_support=$release_support"
                 fi
-
             fi
 
             updates_regular=$(apt-get -qq -y --ignore-hold --allow-change-held-packages --allow-unauthenticated -s dist-upgrade | grep ^Inst | grep -c -v Security)
@@ -81,25 +72,26 @@ case "$1" in
             fi
 
 
-            if sudo -l /usr/sbin/needrestart -b >> /dev/null; then
-                needrestart_info=$(sudo needrestart -b)
-                needrestart_kernel=$(echo "$needrestart_info" | grep -c "NEEDRESTART-KSTA: 3")
-                needrestart_services=$(echo "$needrestart_info" | grep -c "NEEDRESTART-SVC")
+            if [ -f /usr/sbin/needrestart ]; then
+                if sudo -v > /dev/null 2>&1 && sudo -l /usr/sbin/needrestart -b > /dev/null 2>&1; then
+                    needrestart_info=$(sudo needrestart -b)
+                    needrestart_kernel=$(echo "$needrestart_info" | grep -c "NEEDRESTART-KSTA: 3")
+                    needrestart_services=$(echo "$needrestart_info" | grep -c "NEEDRESTART-SVC")
 
-                if [ "$needrestart_kernel" -eq 1 ] && [ "$needrestart_services" -gt 0 ]; then
-                    needrestart_severity=3
-                elif [ "$needrestart_kernel" -eq 1 ]; then
-                    needrestart_severity=2
-                elif [ "$needrestart_services" -gt 0 ]; then
-                    needrestart_severity=1
-                else
-                    needrestart_severity=0
+                    if [ "$needrestart_kernel" -eq 1 ] && [ "$needrestart_services" -gt 0 ]; then
+                        needrestart_severity=3
+                    elif [ "$needrestart_kernel" -eq 1 ]; then
+                        needrestart_severity=2
+                    elif [ "$needrestart_services" -gt 0 ]; then
+                        needrestart_severity=1
+                    else
+                        needrestart_severity=0
+                    fi
+
+                    echo "apt needrestart_services=$needrestart_services"
+                    echo "apt needrestart_severity=$needrestart_severity"
                 fi
-
-                echo "apt needrestart_services=$needrestart_services"
-                echo "apt needrestart_severity=$needrestart_severity"
             fi
-
 
             pkill -P $$
             sleep infinity &


### PR DESCRIPTION
My attempt at resolving #3. Added Ubuntu support including checking support status via the meta-release changelog.

Rather than create additional fields specifically for Ubuntu I added a debian_id field (which returns the capitalized value of /etc/os-release's ID). The other field names remain the same.

This reworks the method used for determining the Debian version, opting to use VERSION_ID from /etc/os-release since it can be used for both Debian and Ubuntu. Tested with Debian 12.9 and Ubuntu 24.10.

I believe this will actually work on all Debian/apt-based distributions, with exception to the support status which will be limited to Debian and Ubuntu, so long as /etc/os-release is structured similarly to Debian and Ubuntu.





